### PR TITLE
remove quotes from autostart.sh

### DIFF
--- a/etc/skel/.config/awesome/autostart.sh
+++ b/etc/skel/.config/awesome/autostart.sh
@@ -6,28 +6,28 @@ function run {
     $@&
   fi
 }
-run "dex $HOME/.config/autostart/arcolinux-welcome-app.desktop"
-#run "xrandr --output VGA-1 --primary --mode 1360x768 --pos 0x0 --rotate normal"
-#run "xrandr --output HDMI2 --mode 1920x1080 --pos 1920x0 --rotate normal --output HDMI1 --primary --mode 1920x1080 --pos 0x0 --rotate normal --output VIRTUAL1 --off"
-run "nm-applet"
-#run "caffeine"
-run "pamac-tray"
-run "variety"
-run "xfce4-power-manager"
-run "blueberry-tray"
-run "/usr/lib/polkit-gnome/polkit-gnome-authentication-agent-1"
-run "numlockx on"
-run "volumeicon"
-#run "nitrogen --restore"
-run "conky -c $HOME/.config/awesome/system-overview"
+run dex $HOME/.config/autostart/arcolinux-welcome-app.desktop
+#xrandr --output VGA-1 --primary --mode 1360x768 --pos 0x0 --rotate normal
+#xrandr --output HDMI2 --mode 1920x1080 --pos 1920x0 --rotate normal --output HDMI1 --primary --mode 1920x1080 --pos 0x0 --rotate normal --output VIRTUAL1 --off
+run nm-applet
+#run caffeine
+run pamac-tray
+run variety
+run xfce4-power-manager
+run blueberry-tray
+run /usr/lib/polkit-gnome/polkit-gnome-authentication-agent-1
+run numlockx on
+run volumeicon
+#run nitrogen --restore
+run conky -c $HOME/.config/awesome/system-overview
 #you can set wallpapers in themes as well
 feh --bg-fill /usr/share/backgrounds/arcolinux/arco-wallpaper.jpg &
 #run applications from startup
-#run "firefox"
-#run "atom"
-#run "dropbox"
-#run "insync start"
-#run "spotify"
-#run "ckb-next -b"
-#run "discord"
-#run "telegram-desktop"
+#run firefox
+#run atom
+#run dropbox
+#run insync start
+#run spotify
+#run ckb-next -b
+#run discord
+#run telegram-desktop


### PR DESCRIPTION
This error was getting printed to `~/.xsession-errors` because of the quotes in autostart.sh:
```
pgrep: only one pattern can be provided
Try `pgrep --help' for more information.
```
Also when uncommenting `run "nitrogen --restore"` this was also there:
```
pgrep: unrecognized option '--restore'
```
(Plus the big help message of pgrep with usage, options, etc)

As shown in [ArchWiki](https://wiki.archlinux.org/index.php/awesome#Autostart), commands can be added with this format: `run program [some arguments]` so I fixed the errors removing the quotes.